### PR TITLE
cycle through players to change who starts every game

### DIFF
--- a/src/Dominion.hs
+++ b/src/Dominion.hs
@@ -49,10 +49,9 @@ dominionWithOpts options list = do
         actionCards   = take (10 - (length requiredCards)) actionCards_ ++ requiredCards
         cards         = concatMap pileOf $ CA.treasureCards ++ CA.victoryCards ++ (take 10 actionCards)
     when verbose_ $ putStrLn $ "Playing with: " ++ (join ", " . map T._name $ actionCards)
-    -- TODO we should cycle through all players to give each one an even chance at going first
-    results <- forM [1..iterations] $ \i -> if even i
-                                        then run (T.GameState players cards 1 verbose_) strategies
-                                        else run (T.GameState (reverse players) cards 1 verbose_) (reverse strategies)
+    let rotate n xs = (drop n' xs) ++ (take n' xs)
+                      where n' = n `mod` length xs
+    results <- forM [1..iterations] $ \i -> run (T.GameState (rotate i players) cards 1 verbose_) (rotate i strategies)
     let winnerNames = (map T.winner results)
     forM_ players $ \player -> do
       let name = player ^. T.playerName


### PR DESCRIPTION
It might also be a good idea to (perhaps optionally) randomly permute player order, but I think this solves your TODO.  I'm not sure if you would prefer to put the definition of rotate somewhere else.
