### PR TITLE
Add a test for throning a feast.

### DIFF
--- a/spec/Main.hs
+++ b/spec/Main.hs
@@ -66,3 +66,10 @@ main = do
               playerId `plays` CA.market
               player <- getPlayer playerId
               return $ player ^. T.actions == 1 && player ^. T.extraMoney == 1 && player ^. T.buys == 2
+      describe "Feast" $ do
+        it "should only trash itself once" $ do
+          io True $ do
+            withHand (CA.throneRoom : replicate 3 CA.feast) $ \playerId -> do
+              playerId `plays` CA.throneRoom `with` (T.ThroneRoom CA.feast) `withMulti` (replicate 2 $ T.Feast CA.duchy)
+              player <- getPlayer playerId
+              return $ player ^. T.hand == replicate 2 CA.feast && player ^. T.discard == replicate 3 CA.duchy


### PR DESCRIPTION
I added a (failing) test for the behavior when playing Throne Room on Feast. The Feast should get trashed after gaining two Duchies, but instead it is discarded. I checked with Debug.Trace, and the player's Throne Room and Feast go into his discard pile instead of the trash; it would be nice to show that somehow in the test output, but this is my first time working with tests in haskell and I don't know how.

The fix for this is that (a) cards must go into the play area when played, and only get discarded at the end of a turn, during the cleanup phase, and (b) the Feast must get trashed at some point.
